### PR TITLE
Prevent parallel execution of elm compiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = ({ optimize = isProd(), debug, pathToElm: pathToElm_ } = {}) =>
 
     build.onLoad({ filter: /.*/, namespace }, async args => {
       try {
-        const contents = await elmCompiler.compileToString([args.path], compileOptions);
+        const contents = await elmCompiler.compileToStringSync([args.path], compileOptions);
         return { contents };
       } catch(e) {
         return { errors: [toBuildError(e)] };


### PR DESCRIPTION
Fixes #2 

This makes esbuid slower, naturally, but better slow than unreliable =]

It can be reverted once https://github.com/elm/compiler/issues/2187 gets fixed.