### PR TITLE
Compilation errors don't result in failures

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = ({ optimize = isProd(), debug, pathToElm: pathToElm_ } = {}) =>
 
     build.onLoad({ filter: /.*/, namespace }, async args => {
       try {
-        const contents = await elmCompiler.compileToStringSync([args.path], compileOptions);
+        const contents = elmCompiler.compileToStringSync([args.path], compileOptions);
         return { contents };
       } catch(e) {
         return { errors: [toBuildError(e)] };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "dependencies": {
     "command-exists": "^1.2.9",
-    "node-elm-compiler": "^5.0.5"
+    "node-elm-compiler": "^5.0.6"
   },
   "peerDependencies": {
     "esbuild": "^0.8.51"

--- a/yarn.lock
+++ b/yarn.lock
@@ -118,10 +118,10 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-elm-compiler@^5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/node-elm-compiler/-/node-elm-compiler-5.0.5.tgz#a47c027d766d0fba53ea0f19c8e2e82992e9c87d"
-  integrity sha512-vapB+VkmKMY1NRy7jjpGjzwWbKmtiRfzbgVoV/eROz5Kx30QvY0Nd5Ua7iST+9utrn1aG8cVToXC6UWdEO5BKQ==
+node-elm-compiler@^5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/node-elm-compiler/-/node-elm-compiler-5.0.6.tgz#d4a6e6c9d9a26dba4211ccd2aeae7d5e34057f0c"
+  integrity sha512-DWTRQR8b54rvschcZRREdsz7K84lnS8A6YJu8du3QLQ8f204SJbyTaA6NzYYbfUG97OTRKRv/0KZl82cTfpLhA==
   dependencies:
     cross-spawn "6.0.5"
     find-elm-dependencies "^2.0.4"


### PR DESCRIPTION
Hi again! Seems like my last PR #3 stepped on a bug in `node-elm-compiler`.

The `compileToStringSync` function never errored out when `elm make` failed due to compilation errors. It failed for ENOENT and some other stuff, but not everyday failures.

I pushed a fix here https://github.com/rtfeldman/node-elm-compiler/pull/110

Richard just merged and published a new version to npm.

This PR bumps us to use the new version.

Also took the time to remove the unnecessary `async` I left in the code when changing from `compileToString` to `compileToStringSync`.