### PR TITLE
Cache compilation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,19 @@
 const path = require('path');
-const fs = require('fs');
+const fs = require('fs').promises;
 const elmCompiler = require('node-elm-compiler');
-const cmdExists = require('command-exists').sync;
+const commandExists = require('command-exists');
 
 const namespace = 'elm';
 const fileFilter = /\.elm$/;
 
-const fileExists = p => fs.existsSync(p) && fs.statSync(p).isFile();
+const fileExists = filePath => fs.stat(filePath).then(stat => stat.isFile()).catch(() => false);
 
-const getPathToElm = () => {
-  if (fileExists('./node_modules/.bin/elm')) return './node_modules/.bin/elm'
-  if (cmdExists('elm')) return 'elm'
+const getPathToElm = async () => {
+  let [fileDoesExist, commandDoesExist] = await Promise.all([fileExists('./node_modules/.bin/elm'), commandExists('elm')]);
+  if (fileDoesExist) return './node_modules/.bin/elm';
+  if (commandDoesExist) return 'elm';
 
-  throw new Error('Could not find `elm` executable. You can install it with `yarn add elm` or `npm install elm`')
+  throw new Error('Could not find `elm` executable. You can install it with `yarn add elm` or `npm install elm`');
 };
 
 const toBuildError = error => ({ text: error.message });

--- a/index.js
+++ b/index.js
@@ -18,9 +18,9 @@ const getPathToElm = async () => {
 
 const toBuildError = error => ({ text: error.message });
 
-const validateDependencies = async depsMap => {
+const validateDependencies = async (fileCache, depsMap) => {
   const depStatus = await Promise.all([...depsMap].map(async ([depPath, cachedDep]) => {
-    const newInput = await fs.readFile(depPath, 'utf8');
+    const newInput = await readFile(fileCache, depPath);
 
     if (cachedDep.input === newInput) {
       return true;
@@ -32,11 +32,11 @@ const validateDependencies = async depsMap => {
   return depStatus.every(isReady => isReady);
 };
 
-const checkCache = async (cache, mainFilePath, compileOptions) => {
+const checkCache = async (fileCache, cache, mainFilePath, compileOptions) => {
   const cached = cache.get(mainFilePath);
-  const newInput = await fs.readFile(mainFilePath, 'utf8');
+  const newInput = await readFile(fileCache, mainFilePath);
 
-  const depsUnchanged = await validateDependencies(cached.dependencies);
+  const depsUnchanged = await validateDependencies(fileCache, cached.dependencies);
 
   if (depsUnchanged && cached.input === newInput) {
     return cached.output;
@@ -70,9 +70,9 @@ const updateDependencies = (cache, resolvedPath, dependencyPaths) => {
 const cachedElmCompiler = () => {
   const cache = new Map();
 
-  const compileToStringSync = async (inputPath, compileOptions) => {
+  const compileToStringSync = async (fileCache, inputPath, compileOptions) => {
     try {
-      const output = await checkCache(cache, inputPath, compileOptions);
+      const output = await checkCache(fileCache, cache, inputPath, compileOptions);
 
       return output;
     } catch (e) {
@@ -101,6 +101,11 @@ module.exports = (config = {}) => ({
 
     const { cache, compileToStringSync } = cachedElmCompiler();
 
+    const fileCache = new Map();
+    build.onStart(() => {
+      fileCache.clear();
+    });
+
     build.onResolve({ filter: fileFilter }, async (args) => {
       const resolvedPath = path.join(args.resolveDir, args.path);
       const resolvedDependencies = await elmCompiler.findAllDependencies(resolvedPath);
@@ -121,7 +126,21 @@ module.exports = (config = {}) => ({
         console.clear();
       }
 
-      return compileToStringSync(args.path, compileOptions);
+      return compileToStringSync(fileCache, args.path, compileOptions);
     });
   },
 });
+
+
+const readFile = async (fileCache, filePath) => {
+  let cached = fileCache.get(filePath);
+
+  if (cached !== undefined) {
+    return cached;
+  } else {
+    let fileContents = await fs.readFile(filePath, 'utf8');
+    fileCache.set(filePath, fileContents);
+
+    return fileContents
+  }
+}

--- a/index.js
+++ b/index.js
@@ -18,13 +18,79 @@ const getPathToElm = async () => {
 
 const toBuildError = error => ({ text: error.message });
 
+const validateDependencies = async depsMap => {
+  const depStatus = await Promise.all([...depsMap].map(async ([depPath, cachedDep]) => {
+    const newInput = await fs.readFile(depPath, 'utf8');
+
+    if (cachedDep.input === newInput) {
+      return true;
+    }
+    cachedDep.input = newInput;
+    return false;
+  }));
+
+  return depStatus.every(isReady => isReady);
+};
+
+const checkCache = async (cache, mainFilePath, compileOptions) => {
+  const cached = cache.get(mainFilePath);
+  const newInput = await fs.readFile(mainFilePath, 'utf8');
+
+  const depsUnchanged = await validateDependencies(cached.dependencies);
+
+  if (depsUnchanged && cached.input === newInput) {
+    return cached.output;
+  }
+  // https://github.com/phenax/esbuild-plugin-elm/issues/2
+  const contents = elmCompiler.compileToStringSync([mainFilePath], compileOptions);
+  const output = { contents };
+
+  cache.set(mainFilePath, {
+    input: newInput,
+    output,
+    dependencies: cached.dependencies,
+  });
+
+  return output;
+};
+
+const updateDependencies = (cache, resolvedPath, dependencyPaths) => {
+  let cached = cache.get(resolvedPath)
+    || { input: undefined, output: undefined, dependencies: new Map() };
+
+  const newValue = depPath => cached.dependencies.get(depPath) || { input: undefined };
+  const dependencies = new Map(dependencyPaths.map(depPath => [depPath, newValue(depPath)]));
+
+  cache.set(resolvedPath, {
+    ...cached,
+    dependencies,
+  });
+};
+
+const cachedElmCompiler = () => {
+  const cache = new Map();
+
+  const compileToStringSync = async (inputPath, compileOptions) => {
+    try {
+      const output = await checkCache(cache, inputPath, compileOptions);
+
+      return output;
+    } catch (e) {
+      return { errors: [toBuildError(e)] };
+    }
+  };
+
+  return { cache, compileToStringSync };
+};
+
+
 module.exports = (config = {}) => ({
   name: 'elm',
-  setup(build) {
-    const isProd = process.env.NODE_ENV === 'production'
+  async setup(build) {
+    const isProd = process.env.NODE_ENV === 'production';
 
-    const { optimize = isProd, debug, clearOnWatch } = config
-    const pathToElm = config.pathToElm || getPathToElm();
+    const { optimize = isProd, debug, clearOnWatch } = config;
+    const pathToElm = config.pathToElm || await getPathToElm();
 
     const compileOptions = {
       pathToElm,
@@ -33,29 +99,29 @@ module.exports = (config = {}) => ({
       debug,
     };
 
+    const { cache, compileToStringSync } = cachedElmCompiler();
+
     build.onResolve({ filter: fileFilter }, async (args) => {
-      const resolvedPath = path.join(args.resolveDir, args.path)
-      const resolvedDependencies = await elmCompiler.findAllDependencies(resolvedPath)
+      const resolvedPath = path.join(args.resolveDir, args.path);
+      const resolvedDependencies = await elmCompiler.findAllDependencies(resolvedPath);
+
+      // I think we need to update deps on each resolve because you might
+      // change your imports on every build
+      updateDependencies(cache, resolvedPath, resolvedDependencies);
 
       return ({
-        path: path.join(args.resolveDir, args.path),
+        path: resolvedPath,
         namespace,
-        watchFiles: [resolvedPath, ...resolvedDependencies]
-      })
-    })
+        watchFiles: [resolvedPath, ...resolvedDependencies],
+      });
+    });
 
-    build.onLoad({ filter: /.*/, namespace }, async args => {
+    build.onLoad({ filter: /.*/, namespace }, async (args) => {
       if (clearOnWatch) {
         console.clear();
       }
 
-      try {
-        const contents = elmCompiler.compileToStringSync([args.path], compileOptions);
-
-        return { contents };
-      } catch (e) {
-        return { errors: [toBuildError(e)] };
-      }
+      return compileToStringSync(args.path, compileOptions);
     });
   },
 });

--- a/index.js
+++ b/index.js
@@ -6,18 +6,26 @@ const commandExists = require('command-exists');
 const namespace = 'elm';
 const fileFilter = /\.elm$/;
 
+// Like command-exists' function but returns undefined when the command is missing,
+// instead of throwing an error.
+const commandExists = path =>
+  commandExists_(path).catch(_ => undefined);
+
 const getPathToElm = async () => {
   const commands = ['./node_modules/.bin/elm', 'elm'];
   const CMD_NOT_FOUND_ERR = 'Could not find `elm` executable. You can install it with `yarn add elm` or `npm install elm`';
 
-  try {
-    const command = await Promise.any(commands.map(command => commandExists(command)));
+  const foundCommands = await Promise.all(commands.map(commandExists));
 
-    return command;
-  } catch (_) {
+  const elmCommand = foundCommands.find(cmd => cmd !== undefined);
+
+  if (elmCommand) {
+    return elmCommand;
+  } else {
     throw new Error(CMD_NOT_FOUND_ERR);
   }
-};
+}
+
 
 const toBuildError = error => ({ text: error.message });
 

--- a/index.js
+++ b/index.js
@@ -6,14 +6,17 @@ const commandExists = require('command-exists');
 const namespace = 'elm';
 const fileFilter = /\.elm$/;
 
-const fileExists = filePath => fs.stat(filePath).then(stat => stat.isFile()).catch(() => false);
-
 const getPathToElm = async () => {
-  let [fileDoesExist, commandDoesExist] = await Promise.all([fileExists('./node_modules/.bin/elm'), commandExists('elm')]);
-  if (fileDoesExist) return './node_modules/.bin/elm';
-  if (commandDoesExist) return 'elm';
+  const commands = ['./node_modules/.bin/elm', 'elm'];
+  const CMD_NOT_FOUND_ERR = 'Could not find `elm` executable. You can install it with `yarn add elm` or `npm install elm`';
 
-  throw new Error('Could not find `elm` executable. You can install it with `yarn add elm` or `npm install elm`');
+  try {
+    const command = await Promise.any(commands.map(command => commandExists(command)));
+
+    return command;
+  } catch (_) {
+    throw new Error(CMD_NOT_FOUND_ERR);
+  }
 };
 
 const toBuildError = error => ({ text: error.message });


### PR DESCRIPTION
## Description
As mentioned in https://github.com/phenax/esbuild-plugin-elm/issues/15, this plugin currently recompiles all main files on successive builds with watch mode.
I've followed https://esbuild.github.io/plugins/#caching-your-plugin which mentions that plugins need to implement caching manually. 
I've done this by simply checking the file contents of elm files (and their dependencies) in new builds against the old ones, if they're the same, the cached output is returned, if not, the compiler is ran, and the cache updated.
This is obviously not great, and I believe the elm compiler does caching directly itself, but it looks like that's not working.