### PR TITLE
Use async version of elm compiler to be able to get the error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = (config = {}) => ({
       }
 
       try {
-        const contents = elmCompiler.compileToStringSync([args.path], compileOptions);
+        const contents = await elmCompiler.compileToString([args.path], compileOptions);
 
         return { contents };
       } catch (e) {


### PR DESCRIPTION
I want to be able to display the error message on the screen, for that I need to capture the error message produced during a compilation error, but this is not possible because the sync function from node-elm-compiler returns just a hardcoded string, as you can see here: https://github.com/rtfeldman/node-elm-compiler/pull/110

Since we are already in an async function, we might as well just use await here and get the proper error message