### PR TITLE
use absolute path to node_modules elm

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const commandExists = path =>
   commandExists_(path).catch(_ => undefined);
 
 const getPathToElm = async () => {
-  const commands = ['./node_modules/.bin/elm', 'elm'];
+  const commands = [path.resolve('./node_modules/.bin/elm'), 'elm'];
   const CMD_NOT_FOUND_ERR = 'Could not find `elm` executable. You can install it with `yarn add elm` or `npm install elm`';
 
   const foundCommands = await Promise.all(commands.map(commandExists));


### PR DESCRIPTION
When esbuild-plugin-elm gets called via other build systems the relative `./node_modules` might not be available where it is executing. 

By making the path absolute we ensure wherever the node_modules elm is installed other process will still be able to execute it.