### PR TITLE
add verbose flag for node-elm-compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ esbuild.build({
 
   The current working directory/elm project root
 
+* `verbose` *(default: `false`)*:
+
+  Enable verbose output of `node-elm-compiler`
+
 
 ### Tutorials
 

--- a/example/build.js
+++ b/example/build.js
@@ -15,6 +15,7 @@ esbuild.build({
       debug: true,
       optimize: isProd,
       clearOnWatch: watch,
+      verbose: true,
     }),
   ],
 }).catch(_e => process.exit(1))

--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ module.exports = (config = {}) => ({
   async setup(build) {
     const isProd = process.env.NODE_ENV === 'production';
 
-    const { optimize = isProd, cwd, debug, clearOnWatch } = config
+    const { optimize = isProd, cwd, debug, verbose, clearOnWatch } = config
     const pathToElm = config.pathToElm || await getPathToElm();
 
     const options = build.initialOptions
@@ -140,6 +140,7 @@ module.exports = (config = {}) => ({
       processOpts: { stdout: 'pipe' },
       cwd,
       debug,
+      verbose,
     };
 
     const { cache, compileToStringSync } = cachedElmCompiler();


### PR DESCRIPTION
`node-elm-compiler` has a verbose flag which can be helpful for users to figure out what is happening under the hood. See [here](https://sourcegraph.com/github.com/rtfeldman/node-elm-compiler/-/blob/src/index.ts?L60:7)

Output without flag:
```
yarn build
yarn run v1.22.17
$ node ./build.js
Dependencies ready!
Success! Compiled 1 module.

    Main ───> /var/folders/1r/5z42n9p52zv8rfp93gxc1vfr0000gn/T/2022716-95289-1q1slzz.ywc4f.js

✨  Done in 5.65s.
```

Output with flag:
```
yarn build
yarn run v1.22.17
$ node ./build.js
Running /Users/william/code/esbuild-plugin-elm/example/node_modules/.bin/elm make /Users/william/code/esbuild-plugin-elm/example/src/Main.elm --debug --output /var/folders/1r/5z42n9p52zv8rfp93gxc1vfr0000gn/T/2022716-96431-1ux81pv.yjyp.js
Success!

    Main ───> /var/folders/1r/5z42n9p52zv8rfp93gxc1vfr0000gn/T/2022716-96431-1ux81pv.yjyp.js

✨  Done in 0.52s.
```