### PR TITLE
Add loadPaths for resolving elm files

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ esbuild.build({
 }).catch(e => (console.error(e), process.exit(1)))
 ```
 
+### Import paths
+
+Import paths will be resolved using the paths listed in `source-directories` in `elm.json`. If none resolve, the import is assumed to be relative to the importing file.
 
 ### Options
 
@@ -56,10 +59,6 @@ esbuild.build({
 * `verbose` *(default: `false`)*:
 
   Enable verbose output of `node-elm-compiler`
-
-* `loadPaths` *(default: `[]`)*:
-
-  Paths in which to look for elm files. If unset, or no file exists at that load path, then the file path is assumed to be relative to the file importing it.
 
 
 ### Tutorials

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ esbuild.build({
 
   Enable verbose output of `node-elm-compiler`
 
+* `loadPaths` *(default: `[]`)*:
+
+  Paths in which to look for elm files. If unset, all paths are assumed to be relative to the file importing them.
+
 
 ### Tutorials
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ esbuild.build({
 
 * `loadPaths` *(default: `[]`)*:
 
-  Paths in which to look for elm files. If unset, all paths are assumed to be relative to the file importing them.
+  Paths in which to look for elm files. If unset, or no file exists at that load path, then the file path is assumed to be relative to the file importing it.
 
 
 ### Tutorials

--- a/index.js
+++ b/index.js
@@ -146,10 +146,10 @@ const resolvePath = async (resolveDir, filePath, loadPaths = []) => {
 };
 
 const getLoadPaths = async (cwd = '.') => {
-  var readFile = await fs.readFile(path.join(cwd, 'elm.json'), 'utf8');
-  var elmPackage = JSON.parse(readFile);
+  const readFile = await fs.readFile(path.join(cwd, 'elm.json'), 'utf8');
+  const elmPackage = JSON.parse(readFile);
 
-  var paths = elmPackage['source-directories'].map((dir) => {
+  const paths = elmPackage['source-directories'].map((dir) => {
       return path.join(cwd, dir);
   });
 

--- a/index.js
+++ b/index.js
@@ -128,21 +128,15 @@ const fileExists = (file) => {
 // If no load paths are provided, or none resolve, the file path is assumed to
 // be relative to `resolveDir`.
 const resolvePath = async (resolveDir, filePath, loadPaths = []) => {
-  const relativePath = path.join(resolveDir, filePath);
-
-  if (loadPaths.length === 0) {
-    return relativePath;
-  }
-
-  for (let loadPath of loadPaths) {
-    let joinedPath = path.join(loadPath, filePath);
+  for (const loadPath of loadPaths) {
+    const joinedPath = path.join(loadPath, filePath);
 
     if (await fileExists(joinedPath)) {
       return joinedPath;
     }
   }
 
-  return relativePath;
+  return path.join(resolveDir, filePath);
 };
 
 const getLoadPaths = async (cwd = '.') => {

--- a/index.js
+++ b/index.js
@@ -123,7 +123,8 @@ const fileExists = (file) => {
   return fs.stat(file).then(stat => stat.isFile()).catch(_ => false);
 };
 
-// Attempts to resolve a file path by joining to each load path.
+// Attempts to resolve a file path by joining to each load path, and returns the
+// resolved path if that file exists.
 // If no load paths are provided, or none resolve, the file path is assumed to
 // be relative to `resolveDir`.
 const resolvePath = async (resolveDir, filePath, loadPaths = []) => {


### PR DESCRIPTION
## Background

We have a lot of elm, some of it doesn't live very close to the JS in our directory structure, meaning that we often have complex relative import paths, which can be easy to get wrong:

```
import { ElmA } from '../../../../../elm/A/Main.elm'
import { ElmB } from '../../../B.elm'
```

Before we moved to esbuild we used `elm-webpack-loader`, which [parses `source-directories` from `elm.json`](https://github.com/elm-community/elm-webpack-loader/blob/master/index.js#L59) and figures out the paths, so that we can have simpler import statements:

```
# elm.json
{ "source-directories": "app/elm", "other/elm", ... }

# In JS
import { ElmA } from "A/Main.elm"
import { ElmB } from "B.elm"
```

There's some precedence for this kind of feature in other esbuild plugins too, for example [esbuild-sass-plugin](https://github.com/glromeo/esbuild-sass-plugin/tree/main#options) accepts a list of `loadPaths` in which to look up files.

## Proposal

This PR would add a `loadPaths` option to `esbuild-plugin-elm` that accepts a list of paths, and tries to resolve import statements against those paths. The scenarios it covers are:

- When no `loadPaths` are provided:
  - maintains current behaviour of looking up a path relative to the importing file
- When `loadPaths` are provided:
  - joins file path to each load path in turn, resolving with the path if a file exists at that location
  - if no load paths resolve, maintains current behaviour and assumes a path relative to the importing file

WDYT? It would make managing our elm imports a little easier!